### PR TITLE
Fix partial reliability setting for data channels

### DIFF
--- a/src/sctp_transport/transport.c
+++ b/src/sctp_transport/transport.c
@@ -495,7 +495,7 @@ static enum rawrtc_code send_message(
         }
 
         // Partial reliability policy
-        switch (ppid) {
+        switch (channel->parameters->channel_type) {
             case RAWRTC_DATA_CHANNEL_TYPE_UNRELIABLE_ORDERED_RETRANSMIT:
             case RAWRTC_DATA_CHANNEL_TYPE_UNRELIABLE_UNORDERED_RETRANSMIT:
                 // Set amount of retransmissions


### PR DESCRIPTION
I was studying your code and by reading the send_message function, I think the partial reliability switch expression is wrong. I did neither test the old code nor compile the proposed changes though.